### PR TITLE
fix: use /usr/bin/env

### DIFF
--- a/src/rimraf.sh
+++ b/src/rimraf.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 set -e
 
 to_remove=$1


### PR DESCRIPTION
I don't have `/usr/local/bin/bash` on macOS 10.15.7

Using `/usr/bin/env` will locate `bash` on any system

Probably fixes #1 too